### PR TITLE
Define the Accesibility-group as a working-group with link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 🔔 Looking for [accessibility docs?](https://jupyter-accessibility.readthedocs.io/en/latest/accessibility-docs.html)
 
 Welcome to the GitHub repository for the [Jupyter](https://jupyter.org/) Accessibility Project.
-This group was formed in early 2019. Its goal is to gather stakeholders interested in working to make Jupyter's
+This [working group](https://jupyter.org/governance/standing_committees_and_working_groups.html) was formed in early 2019. Its goal is to gather stakeholders interested in working to make Jupyter's
 core user-facing software and related tooling accessible.
 
 These core user-facing software include:


### PR DESCRIPTION
Is the accessibility group a working group?  If so, let's simply link to the the meaning of a working-group in the jupyter context.